### PR TITLE
Update EPD_2in13_V3.c

### DIFF
--- a/c/lib/e-Paper/EPD_2in13_V3.c
+++ b/c/lib/e-Paper/EPD_2in13_V3.c
@@ -344,6 +344,26 @@ void EPD_2in13_V3_Display_Base(UBYTE *Image)
 }
 
 /******************************************************************************
+function :	Send lut data and configuration
+parameter:	
+    lut :   lut data
+******************************************************************************/
+static void EPD_2IN13_V2_LUT_by_host(UBYTE *lut)
+{
+	EPD_2IN13_V3_LUT((UBYTE *)lut);			//lut
+	EPD_2in13_V3_SendCommand(0x3f);
+	EPD_2in13_V3_SendData(*(lut+153));
+	EPD_2in13_V3_SendCommand(0x03);	// gate voltage
+	EPD_2in13_V3_SendData(*(lut+154));
+	EPD_2in13_V3_SendCommand(0x04);	// source voltage
+	EPD_2in13_V3_SendData(*(lut+155));	// VSH
+	EPD_2in13_V3_SendData(*(lut+156));	// VSH2
+	EPD_2in13_V3_SendData(*(lut+157));	// VSL
+	EPD_2in13_V3_SendCommand(0x2c);		// VCOM
+	EPD_2in13_V3_SendData(*(lut+158));
+}
+
+/******************************************************************************
 function :	Sends the image buffer in RAM to e-Paper and partial refresh
 parameter:
 	image : Image data


### PR DESCRIPTION
The function in this file `void EPD_2in13_V3_Display_Partial(UBYTE *Image)` calls a non-existent function (`EPD_2IN13_V2_LUT_by_host`), this adds it back.

Otherwise results in the error

```
ld.exe: lib\e-Paper\libePaper.a(EPD_2in13_V3.c.obj): in function `EPD_2in13_V3_Display_Partial':
EPD_2in13_V3.c:(.text.EPD_2in13_V3_Display_Partial+0x26): undefined reference to `EPD_2IN13_V2_LUT_by_host'
```

When trying to build the `c/` folder with cmake.

Found with @greenyrepublic