### PR TITLE
Update EPD_3in7.h

### DIFF
--- a/c/lib/e-Paper/EPD_3in7.h
+++ b/c/lib/e-Paper/EPD_3in7.h
@@ -37,6 +37,10 @@
 #define EPD_3IN7_WIDTH       280
 #define EPD_3IN7_HEIGHT      480 
 
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
 void EPD_3IN7_4Gray_Clear(void);
 void EPD_3IN7_4Gray_Init(void);
 void EPD_3IN7_4Gray_Display(const UBYTE *Image);
@@ -48,4 +52,8 @@ void EPD_3IN7_1Gray_Display_Part(const UBYTE *Image, UWORD Xstart, UWORD Ystart,
 
 void EPD_3IN7_Sleep(void);
 
+#ifdef __cplusplus
+  }
+#endif
+ 
 #endif


### PR DESCRIPTION
Fix error if functions are called from C++, to allow examples to compile when using `EPD_3IN7`

This is because the C++ linker tries to mangle the reference when linking to a C library such as this, resulting in the error:

```
[build] [ 72%] Linking CXX executable pidroponics.elf
[build] ld.exe: CMakeFiles/pidroponics.dir/PidroDisplay.cpp.obj: in function `_ZN11PiDroponics12PidroDisplay11GetInstanceEv':
[build] PidroDisplay.cpp:(.text._ZN11PiDroponics12PidroDisplay11GetInstanceEv+0x16): undefined reference to `_Z19EPD_3IN7_4Gray_Initv'
[build] ld.exe: PidroDisplay.cpp:(.text._ZN11PiDroponics12PidroDisplay11GetInstanceEv+0x1a): undefined reference to `_Z20EPD_3IN7_4Gray_Clearv'
[build] collect2.exe: error: ld returned 1 exit status
```

Found with @GreenyRepublic